### PR TITLE
Fix replication update

### DIFF
--- a/controllers/harborconfiguration_controller.go
+++ b/controllers/harborconfiguration_controller.go
@@ -258,7 +258,12 @@ func (r *HarborConfigurationReconciler) replicationRuleReconciliation(ctx contex
 		if err != nil {
 			return ctrl.Result{}, err
 		}
+		// If ErrReplicationNameAlreadyExists is returned, it is because there is no new
+		// information to update the object with.
 		err = client.UpdateReplicationPolicy(ctx, &update, replicationFound.ID)
+		if errors.Is(err, &rep.ErrReplicationNameAlreadyExists{}) {
+			err = fmt.Errorf("no update required: %w", err)
+		}
 		if err != nil {
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
Replication update was throwing an error when pushing an object with the same information. Instead of sending a 200 or handling with a different error it was returning "Replication name already exists". We added a different error to print in case this happens.