### PR TITLE
Remove dependency on Replication field for getting registry IDs

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,14 +1,14 @@
 # Fixed in https://github.com/beego/beego/releases/tag/v1.12.11 which is available in https://github.com/goharbor/harbor/releases/tag/v2.5.4. However, it appears that it's more likely that this PR (https://github.com/goharbor/harbor-operator/pull/970) will be merged first which also takes in beegov1.12.11.
-CVE-2022-31836 until=2023-06-30
+CVE-2022-31836 until=2023-12-01
 
 # The https://github.com/mittwald/goharbor-client is using v2.4.1 of harbor, to mitigate this CVE it needs to be updated to v2.5.4 or v2.6.2
-CVE-2021-27116 until=2023-06-30
-CVE-2021-27117 until=2023-06-30
-sonatype-2020-0472 until=2023-06-30
-sonatype-2022-5277 until=2023-06-30
+CVE-2021-27116 until=2023-12-01
+CVE-2021-27117 until=2023-12-01
+sonatype-2020-0472 until=2023-12-01
+sonatype-2022-5277 until=2023-12-01
 
 # This CVE doesn't appear to impact this project
-CVE-2021-39391 until=2023-11-22
+CVE-2021-39391 until=2023-12-01
 
 # This CVE is addressed in harbor v2.5.4 which is using v1.5.13 and in harbor v2.6.2 which is using v.1.6.6
 CVE-2022-31030 until=2023-06-30
@@ -20,6 +20,7 @@ CVE-2022-23526 until=2023-06-30
 
 # pkg:golang/k8s.io/apiserver@v0.25.0
 sonatype-2022-6522 until=2023-06-30
+CVE-2022-31030 until=2023-12-01
 
 # This is associated with the https://github.com/go-ldap/ldap dependency, the harbor-operator and harbor-config-operator do not currently use this form of authentication.
 sonatype-2020-1055
@@ -35,11 +36,11 @@ CVE-2022-29153
 
 
 # An updated to jetstack/cert-manager to v1.10.1 within the harbor-operator and harbor-config-operator might mitiate this vulnerability. Unable to find trace of OSS Index ID.
-sonatype-2021-3619 until=2023-06-30
+sonatype-2021-3619 until=2023-12-01
 
 # No documented fixes found for gorm v1.9.8. The vulnerability description seems to suggest that it's fixed post v1.9.10
 # https://github.com/go-gorm/gorm/pull/2674#issuecomment-552668356 mentions it
-CVE-2019-15562 until=2023-06-30
+CVE-2019-15562 until=2023-12-01
 
 # minio v6.0.57 used by harbor-operator v1.3 - no details found
 sonatype-2022-5369
@@ -49,15 +50,8 @@ sonatype-2019-0890
 
 # Found in the prometheus/client-golang@v1.11.0, there exists a patch update which addresses this issue
 # raised a PR - https://github.com/goharbor/harbor-operator/pull/985
-CVE-2022-21698 until=2023-06-30
+CVE-2022-21698 until=2023-12-01
 
 # Issue in golang.org/x/text@v0.3.7, looks like it's been patched and merged https://github.com/golang/go/issues/56152
 # used by multiple dependencies
-CVE-2022-32149 until=2023-06-30
-
-# Package not used by harbor-config-operator
-CVE-2022-23471 until=2023-06-30
-
-# Issue in golang/golang.org/x/net@v0.2.0, looks like it's been patched and merged https://github.com/golang/go/issues/56350
-# waiting for a release
-CVE-2022-41717 until=2023-06-30
+CVE-2022-32149 until=2023-12-01

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -55,3 +55,20 @@ CVE-2022-21698 until=2023-12-01
 # Issue in golang.org/x/text@v0.3.7, looks like it's been patched and merged https://github.com/golang/go/issues/56152
 # used by multiple dependencies
 CVE-2022-32149 until=2023-12-01
+
+# Bug with containerd that is fixed in containerd 1.6.12 and 1.5.16
+CVE-2022-23471 until=2023-12-01
+
+# Go default library net/http has a memory groeth bug as of 1.19.0
+CVE-2022-41717 until=2023-12-01
+
+# Helm versions prior to 3.10.3 can be subjected to uncontrolled resource consumption. Upgrade to >= 3.10.3 to fix.
+CVE-2022-23524 until=2023-12-01
+
+# Helm versions prior to 3.10.3 are subject to NULL Pointer Dereference. Upgrade to >= 3.10.3 to fix.
+CVE-2022-23525 until=2023-12-01
+CVE-2022-23526 until=2023-12-01
+
+# Vnformation exposure vunerability within k8s.io/apiserver as of:  https://github.com/kubernetes/apiserver/commit/76a233ebec7963131ddf3f59221bef5387d5b8ac
+# No more information available.
+sonatype-2022-6522 until=2023-12-01

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ make build
 To run the controller locally against a local kind cluster, it's recommnded to port-forward to the `harbor-core` pod and set the HARBOR_CORE_URL. For instance:
 
 - ```sh
-  kubectl -n harbor-cluster port-forward $(kubectl -n harbor-cluster get pods -l goharbor.io/operator-controller=core -ojson | jq -r '.items[].metadata.name') 8080:80
+  kubectl -n harbor-cluster port-forward $(kubectl -n harbor-cluster get pods -l goharbor.io/operator-controller=core -ojson | jq -r '.items[].metadata.name') 8080:8080
   ```
 
 - ```sh

--- a/api/v1alpha1/harborconfiguration_types.go
+++ b/api/v1alpha1/harborconfiguration_types.go
@@ -84,9 +84,10 @@ type RegistryCredential struct {
 }
 
 type ProjectReq struct {
-	ProjectName  string `json:"projectName,omitempty"`
-	StorageQuota *int64 `json:"storageQuota,omitempty"`
-	Public       *bool  `json:"public,omitempty"`
+	ProjectName            string `json:"projectName,omitempty"`
+	StorageQuota           *int64 `json:"storageQuota,omitempty"`
+	Public                 *bool  `json:"public,omitempty"`
+	ProxyCacheRegistryName string `json:"proxyCacheRegistryName,omitempty"`
 }
 
 type Replication struct {

--- a/config/crd/bases/administration.harbor.configuration_harborconfigurations.yaml
+++ b/config/crd/bases/administration.harbor.configuration_harborconfigurations.yaml
@@ -46,6 +46,8 @@ spec:
                 properties:
                   projectName:
                     type: string
+                  proxyCacheRegistryName:
+                    type: string
                   public:
                     type: boolean
                   storageQuota:

--- a/config/samples/configure-giantswarm-project.yaml
+++ b/config/samples/configure-giantswarm-project.yaml
@@ -1,0 +1,19 @@
+apiVersion: administration.harbor.configuration/v1alpha1
+kind: HarborConfiguration
+metadata:
+  name: setup-giantswarm-project
+spec:
+  harborTarget:
+    name: harbor-cluster
+    namespace: harbor-cluster
+    harborUsername: admin
+  registry:
+    name: docker
+    provider: docker-hub
+    endpointUrl: https://hub.docker.com
+    description: pull from dockerhub
+  projectReq:
+    projectName: giantswarm
+    storageQuota: -1
+    public: true
+    proxyCacheRegistryName: docker

--- a/controllers/harborconfiguration_controller.go
+++ b/controllers/harborconfiguration_controller.go
@@ -153,7 +153,7 @@ func (r *HarborConfigurationReconciler) registryReconciliation(ctx context.Conte
 			update.AccessSecret = &harborConfiguration.Spec.Registry.Credential.AccessSecret
 			update.CredentialType = &harborConfiguration.Spec.Registry.Credential.Type
 		}
-		srcRegistry, err := client.GetRegistryByName(ctx, harborConfiguration.Spec.Replication.RegistryName)
+		srcRegistry, err := client.GetRegistryByName(ctx, harborConfiguration.Spec.Registry.Name)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/controllers/harborconfiguration_controller.go
+++ b/controllers/harborconfiguration_controller.go
@@ -412,7 +412,7 @@ func deleteProject(ctx context.Context, harborConfiguration harborconfigurationv
 }
 
 func deleteRegistry(ctx context.Context, harborConfiguration harborconfigurationv1alpha1.HarborConfiguration, client *apiv2.RESTClient) (ctrl.Result, error) {
-	srcRegistry, err := client.GetRegistryByName(ctx, harborConfiguration.Spec.Replication.RegistryName)
+	srcRegistry, err := client.GetRegistryByName(ctx, harborConfiguration.Spec.Registry.Name)
 	if errors.Is(err, &harborerrors.ErrRegistryNotFound{}) {
 		return ctrl.Result{}, err
 	}

--- a/controllers/harborconfiguration_controller.go
+++ b/controllers/harborconfiguration_controller.go
@@ -170,7 +170,7 @@ func (r *HarborConfigurationReconciler) registryReconciliation(ctx context.Conte
 }
 
 func (r *HarborConfigurationReconciler) projectReconciliation(ctx context.Context, harborConfiguration harborconfigurationv1alpha1.HarborConfiguration, registry modelv2.Registry, client *apiv2.RESTClient) (ctrl.Result, error) {
-	srcRegistry, err := client.GetRegistryByName(ctx, harborConfiguration.Spec.Replication.RegistryName)
+	srcRegistry, err := client.GetRegistryByName(ctx, harborConfiguration.Spec.ProjectReq.ProxyCacheRegistryName)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/helm/harbor-config-operator/crd/harborconfiguration-crd.yaml
+++ b/helm/harbor-config-operator/crd/harborconfiguration-crd.yaml
@@ -46,10 +46,12 @@ spec:
                 type: object
               projectReq:
                 properties:
-                  public:
-                    type: boolean
                   projectName:
                     type: string
+                  proxyCacheRegistryName:
+                    type: string
+                  public:
+                    type: boolean
                   storageQuota:
                     format: int64
                     type: integer
@@ -63,8 +65,8 @@ spec:
                           is 'basic'.
                         type: string
                       access_secret:
-                        description: Access secret, e.g. password when credential type
-                          is 'basic'.
+                        description: Access secret, e.g. password when credential
+                          type is 'basic'.
                         type: string
                       type:
                         description: Credential type, such as 'basic', 'oauth'.
@@ -72,9 +74,9 @@ spec:
                     type: object
                   description:
                     type: string
-                  name:
-                    type: string
                   endpointUrl:
+                    type: string
+                  name:
                     type: string
                   provider:
                     type: string
@@ -127,3 +129,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+


### PR DESCRIPTION
- Updated methods so that the name of the registry can be taken from each individual section.
- Updated the nancy.ignore file to last longer and include new CVEs
- Rebased from main